### PR TITLE
feat: calcula costo de ingredientes automaticamente

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -62,6 +62,7 @@ function inicializarDatos() {
     actualizarSelectProductos();
     actualizarDashboard();
     actualizarGraficosDashboard();
+    actualizarCostoIngredientes();
 }
 
 function showTab(tabName, evt) {
@@ -159,6 +160,7 @@ function actualizarTablaGastos() {
                 <td><button class="delete-btn" onclick="eliminarGasto(${index})">Eliminar</button></td>
             `;
         });
+    actualizarCostoIngredientes();
 }
 // Filtros Gastos
 ['busquedaGastos','filtroFechaDesdeGasto','filtroFechaHastaGasto','filtroCategoriaGasto'].forEach(id=>{
@@ -177,6 +179,18 @@ function eliminarGasto(index) {
     actualizarDashboard();
     guardarDatos();
     mostrarNotificacion("Gasto eliminado correctamente");
+}
+
+// Actualiza automáticamente el campo de costo de ingredientes
+function actualizarCostoIngredientes() {
+    const totalIngredientes = gastos
+        .filter(g => g.categoria === 'Ingredientes')
+        .reduce((sum, g) => sum + (g.costo || 0), 0);
+    const input = document.getElementById('costoIngredientes');
+    if (input) {
+        input.value = totalIngredientes.toFixed(2);
+    }
+    return totalIngredientes;
 }
 
 function agregarVenta() {


### PR DESCRIPTION
## Summary
- calcula y muestra automáticamente el costo total de ingredientes
- sincroniza el valor calculado al cargar datos y al actualizar gastos

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68923b02dbc4832faeb918f9fcef8b26