### PR TITLE
Add Node test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,12 @@
+{
+  "name": "sweettasting",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "sweettasting",
+      "version": "1.0.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "sweettasting",
+  "version": "1.0.0",
+  "description": "Aplicación PWA para administrar un emprendimiento de postres",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -1,0 +1,8 @@
+function calcularCostoUnitario(costo, cantidad) {
+    if (cantidad === 0) {
+        throw new Error('La cantidad no puede ser cero');
+    }
+    return costo / cantidad;
+}
+
+module.exports = { calcularCostoUnitario };

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { calcularCostoUnitario } = require('../scripts/utils');
+
+test('calcula el costo por unidad', () => {
+  assert.strictEqual(calcularCostoUnitario(100, 4), 25);
+});
+
+test('lanza un error si la cantidad es cero', () => {
+  assert.throws(() => calcularCostoUnitario(100, 0), /La cantidad no puede ser cero/);
+});


### PR DESCRIPTION
## Summary
- add Node-based test configuration via package.json
- include utility function and corresponding tests
- ignore node_modules and coverage folders

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68923c817808832f9d01d60461cb45ac