### PR TITLE
Support Node testing for IndexedDB module

### DIFF
--- a/scripts/db.js
+++ b/scripts/db.js
@@ -124,7 +124,8 @@ async function put(storeName, item) {
 }
 
 
-window.db = {
+// Exporta la API de la base de datos tanto para el navegador como para Node.js.
+const dbAPI = {
     initDB,
     getAll,
     add,
@@ -132,3 +133,13 @@ window.db = {
     put,
     STORES
 };
+
+// En el entorno del navegador, se adjunta a window para acceso global.
+if (typeof window !== 'undefined') {
+    window.db = dbAPI;
+}
+
+// En entornos de Node.js (por ejemplo, durante las pruebas), se exporta mediante module.exports.
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = dbAPI;
+}

--- a/tests/db.test.js
+++ b/tests/db.test.js
@@ -4,34 +4,34 @@ const assert = require('node:assert');
 // Simula IndexedDB en Node.js
 require('fake-indexeddb/auto');
 
-// Carga el script de DB para que se ejecute en el entorno simulado
-require('../scripts/db.js');
+// Importa la API de la base de datos desde el script
+const db = require('../scripts/db.js');
 
 test.describe('Database Operations', () => {
     test('should initialize the database and create object stores', async () => {
-        const db = await window.db.initDB();
-        assert.ok(db instanceof IDBDatabase);
-        assert.ok(db.objectStoreNames.contains(window.db.STORES.gastos));
-        assert.ok(db.objectStoreNames.contains(window.db.STORES.ventas));
-        assert.ok(db.objectStoreNames.contains(window.db.STORES.productos));
+        const database = await db.initDB();
+        assert.ok(database instanceof IDBDatabase);
+        assert.ok(database.objectStoreNames.contains(db.STORES.gastos));
+        assert.ok(database.objectStoreNames.contains(db.STORES.ventas));
+        assert.ok(database.objectStoreNames.contains(db.STORES.productos));
     });
 
     test('should add and get an item from a store', async () => {
         const newItem = { concepto: 'Harina', costo: 500 };
-        const id = await window.db.add(window.db.STORES.gastos, newItem);
+        const id = await db.add(db.STORES.gastos, newItem);
         assert.strictEqual(typeof id, 'number');
 
-        const allItems = await window.db.getAll(window.db.STORES.gastos);
+        const allItems = await db.getAll(db.STORES.gastos);
         assert.strictEqual(allItems.length, 1);
         assert.strictEqual(allItems[0].concepto, 'Harina');
     });
 
     test('should remove an item from a store', async () => {
         const newItem = { concepto: 'Azúcar', costo: 700 };
-        const id = await window.db.add(window.db.STORES.gastos, newItem);
-        
-        await window.db.remove(window.db.STORES.gastos, id);
-        const item = await window.db.getAll(window.db.STORES.gastos);
+        const id = await db.add(db.STORES.gastos, newItem);
+
+        await db.remove(db.STORES.gastos, id);
+        const item = await db.getAll(db.STORES.gastos);
         // Filtramos para buscar el que acabamos de borrar
         const deletedItem = item.find(i => i.id === id);
         assert.strictEqual(deletedItem, undefined);


### PR DESCRIPTION
## Summary
- Expose IndexedDB helpers in `scripts/db.js` without relying on `window`
- Update database tests to import the module directly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bf9865f74832f92f0c51546b31ebe